### PR TITLE
S3t next button

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -70,3 +70,4 @@ const getAndDisplayCountry = countries => {
 const enableNewWordButton = (enabled) => {
     document.getElementById('nextButton').disabled = !enabled
 }
+

--- a/functions.js
+++ b/functions.js
@@ -62,3 +62,11 @@ const getAndDisplayCountry = countries => {
     displayCountry(countryObject)
     return countryObject
 }
+
+/**
+ * function to enable or disable the next button
+ * @param {boolean} enabled if true the next button is enabled otherwise disabled
+ */
+const enableNewWordButton = (enabled) => {
+    document.getElementById('nextButton').disabled = !enabled
+}

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                         <div id="hintButton" >
                             <p id="hint"></p>
                         </div>
-                        <button id="nextButton">
+                        <button id="nextButton" disabled>
                             Next
                         </button>
                     </div>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                         </div>
                     </div>
                     <div class="buttonContainer">
-                        <button>
+                        <button id="revealButton">
                             Reveal
                         </button>
                         <div id="hintButton" >

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 let countries = []
-let currentCountryObject = {}
+let country
 
 fetch('countries.json')
     .then(countryData => countryData.json())
@@ -10,11 +10,11 @@ fetch('countries.json')
 document.getElementById('startButton').addEventListener('click', () => {
     if (countries.length) {
         startGame()
-        currentCountryObject = getAndDisplayCountry(countries)
+        country = getAndDisplayCountry(countries)
     }
 })
 
 document.getElementById('revealButton').addEventListener('click', () => {
-    document.getElementById('anagram').textContent = currentCountryObject.name
+    document.getElementById('anagram').textContent = country.name
     enableNewWordButton(true)
 })

--- a/index.js
+++ b/index.js
@@ -12,3 +12,5 @@ document.getElementById('startButton').addEventListener('click', () => {
         getAndDisplayCountry(countries)
     }
 })
+
+enableNewWordButton(true);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 let countries = []
+let currentCountryObject = {}
 
 fetch('countries.json')
     .then(countryData => countryData.json())
@@ -9,8 +10,11 @@ fetch('countries.json')
 document.getElementById('startButton').addEventListener('click', () => {
     if (countries.length) {
         startGame()
-        getAndDisplayCountry(countries)
+        currentCountryObject = getAndDisplayCountry(countries)
     }
 })
 
-enableNewWordButton(true);
+document.getElementById('revealButton').addEventListener('click', () => {
+    document.getElementById('anagram').textContent = currentCountryObject.name
+    enableNewWordButton(true)
+})

--- a/styles.css
+++ b/styles.css
@@ -41,13 +41,16 @@ h2 {
 }
 
 .buttonContainer > button {
-    width: 100px;
-    height: 40px;
+    padding: 8px 16px;
     background-color: #1D95EC;
     color: #fff;
     border-style: none;
     border-radius: 10px;
     font-size: 1.2rem;
+}
+
+.buttonContainer > button:disabled {
+    background-color: #d3d3d3;
 }
 
 .gameNav {


### PR DESCRIPTION
This pull request should enable the enable/disable the next button feature.  The reveal button also reveals the answer and enables the next button.

There's only a few things left to do which could be done in other task branches (also available on the trello board):
Add an event listener to the next button that calls the newWord function when clicked
In the text input keyup even listener, call the enableNewWordButton function with a parameter of true when the answer is correct.